### PR TITLE
molecule: necessary changes for 3.0

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,16 +3,13 @@ dependency:
   name: galaxy
 driver:
   name: openstack
-lint:
-  name: yamllint
-  options:
-    config-file: molecule/default/yamllint.yml
+lint: |
+  yamllint -c molecule/default/yamllint.yml .
+  ansible-lint --exclude molecule
 platforms:
   - name: $PLATFORM_NAME
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
   inventory:
     group_vars:
       all:

--- a/molecule/default/yamllint.yml
+++ b/molecule/default/yamllint.yml
@@ -1,6 +1,10 @@
 ---
 extends: default
 
+ignore: |
+  .tox
+  .git
+
 rules:
   line-length:
     max: 200

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,6 @@
-molecule[openstack]>=2.0
+ansible-lint
+molecule-openstack
+molecule>=3.0
 openstacksdk
 paramiko
 shade


### PR DESCRIPTION
This will fix the following issue with molecule 3.x:

{'driver': [{'name': ['unallowed value openstack']}], 'lint': ['must be of string type']}